### PR TITLE
Install zkllvm-libc.ll and related headers by default

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -184,3 +184,15 @@ endif ()
 #add_test(NAME tstddef COMMAND tstddef)
 
 add_circuit_no_stdlib(zkllvm-libc SOURCES zk/malloc.c)
+
+# Make sure zkllvm-libc builds as part of "all"
+add_custom_target(zkllvm-libc-all ALL DEPENDS zkllvm-libc)
+
+if (CIRCUIT_ASSEMBLY_OUTPUT)
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/zkllvm-libc.ll DESTINATION lib/zkllvm)
+else()
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/zkllvm-libc.bc DESTINATION lib/zkllvm)
+endif()
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/ DESTINATION include/zkllvm)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../libcpp/ DESTINATION include/zkllvm/c++)


### PR DESCRIPTION
Currently, zkllvm-libc.ll and its headers are installed as a separate package, which has to be manually built.

When doing "cmake && make && make install" in the zkllvm root, I'm seemingly getting everything except the libc. It's not very convenient, as people who build manually kind of expect this approach to just work.

I've added a default installation target that does the right thing in this regard.